### PR TITLE
Adding a bipartmod_w_cl command

### DIFF
--- a/README
+++ b/README
@@ -380,40 +380,9 @@ Please read the bipartmod documentation to learn more about bipartmod_w.
 
 
 -------------------------------------------------------------------------------
-bipartmod
--------------------------------------------------------------------------------
-
-Given a bipartite network, the program returns a partition of the nodes in
-one of the sets of nodes (the 'actors' or the 'teams') obtained according
-to the algorithm described in:
-
-4. Guimera, R., Sales-Pardo, M. & Amaral, L.A.N., Module identification in
-   bipartite and directed networks, Phys. Rev. E 76, 036102 (2007)
-The program will prompt for the following parameters:
-
-- Seed for the random number generator: Must be a positive integer. Since the
-  module identification algorithm is stochastic, different runs will yield,
-  in general, slightly different different modules. Two runs with the same
-  seed, though, should give the exact same results.
-
-- Name of the network file: Name of the file that contains the network. The
-  file must be a list of links with the format:
-
-  n1 n2
-  n3 n4
-  .  .
-  .  .
-  .  .
-
-  This represents a network with a link between nodes n1 and n2, another
-  between nodes n3 and n4, and so on. Nodes must be separated by spaces.
-
-- Iteration factor (f): At each temperature of the simulated annealing (SA),
-  the program performs fN^2 individual-node updates (involving the movement
-  of a single node from one module to another) and fN collective updates
-  (involving the merging of two modules and the split of a module). The number
 reliability
 -------------------------------------------------------------------------------
+
 Given a network observation, the programs in reliability:
 
 1) reliability_links: evaluate the reliability of links

--- a/README
+++ b/README
@@ -290,6 +290,8 @@ to the algorithm described in:
 In case you use the results of the program in a publication, please cite
 the paper above.
 
+This command exists in a interactive (bipartmod) and a batch (bipartmod_cl) mode.
+
 Input parameters
 -------------------------------------------------------------------------------
 
@@ -358,6 +360,8 @@ to the algorithm described in:
 
 In case you use the results of the program in a publication, please cite
 the papers above.
+
+This command exists in a interactive (bipartmod_w) and a batch (bipartmod_w_cl) mode.
 
 Input parameters
 -------------------------------------------------------------------------------

--- a/bipartmod/Makefile.am
+++ b/bipartmod/Makefile.am
@@ -5,13 +5,16 @@ INCLUDES = -I$(top_builddir) -I$(top_srcdir) \
 	-I$(top_srcdir)/lib -I$(top_srcdir)/src
 AM_LDFLAGS = -static
 
-bin_PROGRAMS = bipartmod bipartmod_cl bipartmod_w
+bin_PROGRAMS = bipartmod bipartmod_cl bipartmod_w_cl bipartmod_w
 
 bipartmod_SOURCES = main_bipartmod.c
 bipartmod_LDADD = $(top_srcdir)/src/librgraph.a $(top_srcdir)/lib/libgnu.la
 
 bipartmod_cl_SOURCES = main_bipartmod_cl.c
 bipartmod_cl_LDADD = $(top_srcdir)/src/librgraph.a $(top_srcdir)/lib/libgnu.la
+
+bipartmod_w_cl_SOURCES = main_bipartmod_w_cl.c
+bipartmod_w_cl_LDADD = $(top_srcdir)/src/librgraph.a $(top_srcdir)/lib/libgnu.la
 
 bipartmod_w_SOURCES = main_bipartmod_w.c
 bipartmod_w_LDADD = $(top_srcdir)/src/librgraph.a $(top_srcdir)/lib/libgnu.la

--- a/bipartmod/main_bipartmod_cl.c
+++ b/bipartmod/main_bipartmod_cl.c
@@ -25,23 +25,19 @@ main(int argc, char **argv)
     ------------------------------------------------------------
   */
   if (argc < 6) {
-    printf("\nUse: bipartmod_w_cl net_file_name seed iteration_factor cooling_factor modules_column\n\n");
+    printf("\nUsage: bipartmod_cl net_file_name seed iteration_factor cooling_factor modules_column\n\n"
+		   "\t net_file_name: Name of the network file\n"
+		   "\t seed: Random number seed (POSITIVE Integer) \n"
+		   "\t iteraction_factor: Iteration factor (recommended 1.0)\n"
+		   "\t cooling_factor: Cooling factor (recommended 0.950-0.995)\n" 
+		   "\t module_column: Find modules for the first column (0) or second columnd (1)\n\n");
     return -1;
   }
 
-  //printf("\n# Enter the name of the network file: ");
   file_name = argv[1];
-  
-  //printf("\n# Enter random number seed (POSITIVE integer): ");
   seed = atoi(argv[2]);
-  
-  //printf("\n# Enter iteration factor (recommended 1.0): ");
   fac = atof(argv[3]);
-  
-  //printf("\n# Enter the cooling factor (recommended 0.950-0.995): ");
   Ts = atof(argv[4]);
-  
-  //printf("\n# Find modules from first column (0) or second columnd (1): ");
   invert = atoi(argv[5]);
   
   /*

--- a/bipartmod/main_bipartmod_w_cl.c
+++ b/bipartmod/main_bipartmod_w_cl.c
@@ -1,0 +1,83 @@
+#include <stdio.h>
+#include <math.h>
+#include <stdlib.h>
+
+#include <gsl/gsl_rng.h>
+#include "tools.h"
+#include "graph.h"
+#include "modules.h"
+#include "bipartite.h"
+
+main(int argc, char **argv)
+{
+  FILE *outF, *inF;
+  int seed = 1111;
+  struct binet *binet = NULL;
+  struct group *part = NULL;
+  gsl_rng *randGen;
+  double Ti, Tf, Ts, fac;
+  char *file_name;
+  int invert;
+
+  /*
+    ------------------------------------------------------------
+    Prompt for user-defined parameters
+    ------------------------------------------------------------
+  */
+  if (argc < 6) {
+    printf("\nUsage: bipartmod_cl net_file_name seed iteration_factor cooling_factor modules_column\n\n"
+		   "\t net_file_name: Name of the network file\n"
+		   "\t seed: Random number seed (POSITIVE Integer) \n"
+		   "\t iteraction_factor: Iteration factor (recommended 1.0)\n"
+		   "\t cooling_factor: Cooling factor (recommended 0.950-0.995)\n "
+		   "\t module_column: Find modules for the first column (0) or second columnd (1)\n\n");
+    return -1;
+  }
+
+  file_name = argv[1];
+  seed = atoi(argv[2]);
+  fac = atof(argv[3]);
+  Ts = atof(argv[4]);
+  invert = atoi(argv[5]);
+  
+  /*
+    ------------------------------------------------------------------
+    Initialize the random number generator
+    ------------------------------------------------------------------
+  */
+  randGen = gsl_rng_alloc(gsl_rng_mt19937);
+  gsl_rng_set(randGen, seed);
+
+  /*
+    ------------------------------------------------------------------
+    Build the network
+    ------------------------------------------------------------------
+  */
+  inF = fopen(file_name, "r");
+  binet = FBuildNetworkBipart(inF, 0, 0);
+  fclose(inF);
+  if (invert == 1)
+    InvertBipart(binet);
+
+  /*
+    ------------------------------------------------------------------
+    Find the modules using the bipartite network
+    ------------------------------------------------------------------
+  */
+  Ti = 1. / (double)CountNodes(binet->net1);
+  Tf = 0.;
+
+  part = SACommunityIdentBipartWeighted(binet,
+				Ti, Tf, Ts, fac,
+				0, 'o', 1, 'm',
+				randGen);
+  outF = fopen("modules_bipart.dat", "w");
+  FPrintPartition(outF, part, 0);
+  fclose(outF);
+  RemovePartition(part);
+
+  // Free memory
+  // ------------------------------------------------------------
+  gsl_rng_free(randGen);
+  RemoveBipart(binet);
+}


### PR DESCRIPTION
Adds a bipartmod_w_cl command which is the equivalent of bipartmod_cl for bipartmod_w (i.e. a batch version).
Adds a reference to this in the README (and also fix a duplicated paragraph). 
